### PR TITLE
Fix: variables definition and default tnlcm admin password value

### DIFF
--- a/community-apps/appliances/TNLCM/appliance.sh
+++ b/community-apps/appliances/TNLCM/appliance.sh
@@ -35,15 +35,14 @@ ONE_SERVICE_PARAMS=(
     'ONEAPP_TNLCM_JENKINS_PASSWORD'        'configure'  'Password used to login into the Jenkins server to access and retrieve pipeline info'                      'M|password'
     'ONEAPP_TNLCM_JENKINS_TOKEN'           'configure'  'Token to authenticate while sending POST requests to the Jenkins Server API'                              'M|password'
     'ONEAPP_TNLCM_SITES_TOKEN'             'configure'  'Token to encrypt and decrypt the 6G-Sandbox-Sites repository files for your site using Ansible Vault'     'M|password'
-    'ONEAPP_TNLCM_ADMIN_USER'              'configure'  'Name of the TNLCM admin user. Default: tnlcm'                                                             'O|text'
-    'ONEAPP_TNLCM_ADMIN_PASSWORD'          'configure'  'Password of the TNLCM admin user. Default: tnlcm'                                                         'O|password'
+    'ONEAPP_TNLCM_ADMIN_USER'              'configure'  'Name of the TNLCM admin user'                                                                             'O|text'
+    'ONEAPP_TNLCM_ADMIN_PASSWORD'          'configure'  'Password of the TNLCM admin user'                                                                         'O|password'
 )
 
 ONEAPP_TNLCM_JENKINS_HOST="${ONEAPP_TNLCM_JENKINS_HOST:-127.0.0.1}"
 ONEAPP_TNLCM_JENKINS_USERNAME="${ONEAPP_TNLCM_JENKINS_USERNAME:-admin}"
 ONEAPP_TNLCM_JENKINS_PASSWORD="${ONEAPP_TNLCM_JENKINS_PASSWORD:-admin}"
 ONEAPP_TNLCM_ADMIN_USER="${ONEAPP_TNLCM_ADMIN_USER:-tnlcm}"
-ONEAPP_TNLCM_ADMIN_PASSWORD="${ONEAPP_TNLCM_ADMIN_PASSWORD:-tnlcm}"
 
 
 # ------------------------------------------------------------------------------

--- a/community-apps/metadata/service_TNLCM.yaml
+++ b/community-apps/metadata/service_TNLCM.yaml
@@ -59,12 +59,12 @@ opennebula_template:
   logo: images/logos/ubuntu.png
   user_inputs:
     oneapp_tnlcm_jenkins_host:      "M|text|ONEAPP_TNLCM_JENKINS_HOST: IP address of the Jenkins server used to deploy the Trial Networks| |127.0.0.1"
-    oneapp_tnlcm_jenkins_username:  "M|text|ONEAPP_TNLCM_JENKINS_USERNAME: Username used to login into the Jenkins server to access and retrieve pipeline info. | |admin"
-    oneapp_tnlcm_jenkins_password:  "M|password|ONEAPP_TNLCM_JENKINS_PASSWORD: Password used to login into the Jenkins server to access and retrieve pipeline info. | |admin"
+    oneapp_tnlcm_jenkins_username:  "M|text|ONEAPP_TNLCM_JENKINS_USERNAME: Username used to login into the Jenkins server to access and retrieve pipeline info| |admin"
+    oneapp_tnlcm_jenkins_password:  "M|password|ONEAPP_TNLCM_JENKINS_PASSWORD: Password used to login into the Jenkins server to access and retrieve pipeline info| |admin"
     oneapp_tnlcm_jenkins_token:     "M|password|ONEAPP_TNLCM_JENKINS_TOKEN: Token to authenticate while sending POST requests to the Jenkins Server API"
     oneapp_tnlcm_sites_token:       "M|password|ONEAPP_TNLCM_SITES_TOKEN: Token to encrypt and decrypt the 6G-Sandbox-Sites repository files for your site using Ansible Vault"
-    oneapp_tnlcm_admin_user:        "O|text|ONEAPP_TNLCM_ADMIN_USER: Name of the TNLCM admin user. Default: tnlcm | |tnlcm"
-    oneapp_tnlcm_admin_password:    "O|password|ONEAPP_TNLCM_ADMIN_PASSWORD: Password of the TNLCM admin user. Default: tnlcm| |tnlcm"
+    oneapp_tnlcm_admin_user:        "O|text|ONEAPP_TNLCM_ADMIN_USER: Name of the TNLCM admin user| |tnlcm"
+    oneapp_tnlcm_admin_password:    "O|password|ONEAPP_TNLCM_ADMIN_PASSWORD: Password of the TNLCM admin user"
 logo: tnlcm.png
 images:
   - name: "6G-Sandbox TNLCM"

--- a/community-apps/metadata/toolkit/service_toolkit.yaml
+++ b/community-apps/metadata/toolkit/service_toolkit.yaml
@@ -59,7 +59,7 @@ opennebula_template:
     oneapp_tnlcm_admin_user:                  "O|text|Name of the TNLCM admin user||tnlcm"
     oneapp_tnlcm_admin_password:              "O|password|Password of the TNLCM admin user||"
   networks:                        # Hash of virtual networks to use in the service.
-    Public: "M|network|Public||id"
+    Public: "M|network|Public||id:"
   roles:
     - name: minio           # letters, numbers or underscore
       vm_template_contents: |

--- a/community-apps/metadata/toolkit/service_toolkit.yaml
+++ b/community-apps/metadata/toolkit/service_toolkit.yaml
@@ -56,10 +56,10 @@ opennebula_template:
     oneapp_jenkins_opennebula_username:       "M|text|The OpenNebula username used by Jenkins to deploy each component||"
     oneapp_jenkins_opennebula_password:       "M|password|The password for the OpenNebula user used by Jenkins to deploy each component"
     oneapp_jenkins_opennebula_insecure:       "O|boolean|Allow insecure connexions into the OpenNebula XML-RPC Endpoint API (skip TLS verification)||YES"
-    oneapp_tnlcm_admin_user:                  "O|text|Name of the TNLCM admin user. Default: tnlcm||tnlcm"
-    oneapp_tnlcm_admin_password:              "O|password|Password of the TNLCM admin user. Default: tnlcm||tnlcm"
+    oneapp_tnlcm_admin_user:                  "O|text|Name of the TNLCM admin user||tnlcm"
+    oneapp_tnlcm_admin_password:              "O|password|Password of the TNLCM admin user||"
   networks:                        # Hash of virtual networks to use in the service.
-    Public: "M|network|Public||id:"
+    Public: "M|network|Public||id"
   roles:
     - name: minio           # letters, numbers or underscore
       vm_template_contents: |


### PR DESCRIPTION
- I don't think I break anything on the tnlcm appliance
- Set variable and network definitions for the toolkit installer