### PR TITLE
Upgrade Jenkins appliance to Ubuntu 24.04 (PROESP-2706)

### DIFF
--- a/appliances/.other-appliances/toolkit/toolkit_jenkins.yaml
+++ b/appliances/.other-appliances/toolkit/toolkit_jenkins.yaml
@@ -1,5 +1,5 @@
 ---
-name: "[6G-Sandbox toolkit] Jenkins"
+name: "[6G-Sandbox toolkit] Jenkins 24.04"
 version: "v1.0.0-20250915-1622"  # <software_version>-$(date +"%Y%m%d-%H%M" -d @<creation_time>)
 software_version: "v1.0.0"
 publisher: "Telefonica Innovacion Digital"
@@ -24,7 +24,7 @@ type: VMTEMPLATE
 format: qcow2
 creation_time: 1757953367     # date +%s
 os-id: Ubuntu
-os-release: 22.04 LTS
+os-release: 24.04 LTS
 os-arch: x86_64
 hypervisor: KVM
 opennebula_version: >-
@@ -63,4 +63,4 @@ opennebula_template:
   user_inputs: {}
 logo: jenkins.png
 disks:
-- "6G-Sandbox Jenkins"
+- "6G-Sandbox Jenkins 24.04"

--- a/appliances/.other-appliances/toolkit/toolkit_jenkins_7.0.yaml
+++ b/appliances/.other-appliances/toolkit/toolkit_jenkins_7.0.yaml
@@ -1,5 +1,5 @@
 ---
-name: "[6G-Sandbox toolkit] Jenkins for OpenNebula 7.0"
+name: "[6G-Sandbox toolkit] Jenkins 24.04 for OpenNebula 7.0"
 version: "v1.0.0-20250915-1622"  # <software_version>-$(date +"%Y%m%d-%H%M" -d @<creation_time>)
 software_version: "v1.0.0"
 publisher: "Telefonica Innovacion Digital"
@@ -24,7 +24,7 @@ type: VMTEMPLATE
 format: qcow2
 creation_time: 1757953367     # date +%s
 os-id: Ubuntu
-os-release: 22.04 LTS
+os-release: 24.04 LTS
 os-arch: x86_64
 hypervisor: KVM
 opennebula_version: "6.6, 6.8, 6.10, 7.0"
@@ -62,4 +62,4 @@ opennebula_template:
   user_inputs: {}
 logo: jenkins.png
 disks:
-- "6G-Sandbox Jenkins"
+- "6G-Sandbox Jenkins 24.04"

--- a/appliances/jenkins/appliance.sh
+++ b/appliances/jenkins/appliance.sh
@@ -124,7 +124,7 @@ install_opennebula_cli()
     msg info "Add OpenNebula .deb community repository"
     wget -q -O- https://downloads.opennebula.io/repo/repo2.key | gpg --dearmor --yes --output /etc/apt/keyrings/opennebula.gpg
     chmod 0644 /etc/apt/keyrings/opennebula.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/opennebula.gpg] https://downloads.opennebula.io/repo/6.10/Ubuntu/22.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    echo "deb [signed-by=/etc/apt/keyrings/opennebula.gpg] https://downloads.opennebula.io/repo/6.10/Ubuntu/24.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     wait_for_dpkg_lock_release
     apt-get update
 

--- a/appliances/jenkins/jenkins.yaml
+++ b/appliances/jenkins/jenkins.yaml
@@ -1,11 +1,11 @@
 ---
-name: "6G-Sandbox Jenkins"
+name: "6G-Sandbox Jenkins 24.04"
 version: "autofill"
 software_version: "v1.0.0"
 publisher: "Telefonica Innovacion Digital"
 description: |-
   This appliance installs the latest version of Jenkins LTS from the official download and configures it to be ready to serve a 6G-SANDBOX site.
-  The image is based on an Ubuntu 22.04 cloud image with the OpenNebula [contextualization package](http://docs.opennebula.io/6.6/management_and_operations/references/kvm_contextualization.html).
+  The image is based on an Ubuntu 24.04 cloud image with the OpenNebula [contextualization package](http://docs.opennebula.io/6.6/management_and_operations/references/kvm_contextualization.html).
 
   Run with default values and manually configure the credentials from Jenkins WebUI, or use contextualization variables to automate the bootstrap.
   Default Jenkins credentials (if ONEAPP_JENKINS_USERNAME and ONEAPP_JENKINS_PASSWORD are unspecified) are admin:admin
@@ -37,7 +37,7 @@ tags:
 format: qcow2
 creation_time: "autofill"
 os-id: Ubuntu
-os-release: 22.04 LTS
+os-release: 24.04 LTS
 os-arch: x86_64
 hypervisor: KVM
 opennebula_version: >-

--- a/apps-code/community-apps/packer/jenkins/jenkins.pkr.hcl
+++ b/apps-code/community-apps/packer/jenkins/jenkins.pkr.hcl
@@ -17,7 +17,7 @@ source "qemu" "jenkins" {
   memory      = 4096
   accelerator = "kvm"
 
-  iso_url      = "../one-apps/export/ubuntu2204.qcow2"
+  iso_url      = "../one-apps/export/ubuntu2404.qcow2"
   iso_checksum = "none"
 
   headless = var.headless


### PR DESCRIPTION
# Upgrade Jenkins appliance to Ubuntu 24.04

## Problem
Jenkins VM appliance runs Ubuntu 22.04 with a frozen kernel (5.15.0-144) from the pre-built qcow2 (Sep 2024). After apt upgrades install a newer kernel (5.15.0-177), a mismatch causes "Failed to exec spawn helper, exit value: 1" in OpenNebula context scripts.

## Solution
Upgrade the appliance base OS from Ubuntu 22.04 to **Ubuntu 24.04** (kernel 6.8.x) to avoid future kernel mismatch issues.

## Changes
- **Base image**: `ubuntu2204.qcow2` → `ubuntu2404.qcow2` (`jenkins.pkr.hcl`)
- **OpenNebula repo**: `22.04` → `24.04` (`appliance.sh`)
- **Metadata names**: Appended "24.04" to distinguish from the existing 22.04 appliance
- **Disk references**: Updated in toolkit templates to match the new base name

Existing 22.04 appliance remains unchanged and available for rollback.

Refs: PROESP-2706